### PR TITLE
fix mAP metric unusual result

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ for i in range(10):
     metric_fn.add(preds, gt)
 
 # compute PASCAL VOC metric
-print(f"VOC PASCAL mAP: {metric_fn.value(iou_thresholds=0.5, recall_thresholds=np.arange(0., 1.1, 0.1))['mAP']}")
+print(f"VOC PASCAL mAP: {metric_fn.value(iou_thresholds=0.5, recall_thresholds=np.arange(0., 1.1, 0.1)).astype(np.float32)['mAP']}")
 
 # compute PASCAL VOC metric at the all points
 print(f"VOC PASCAL mAP in all points: {metric_fn.value(iou_thresholds=0.5)['mAP']}")


### PR DESCRIPTION
floating point precision limitation of np.arange() in float64 is fixed by converting recall_thresholds to float32 before calculating mAP. Note that even float16 is more than enough for range of numbers in this application.